### PR TITLE
Revert loose number parsing to pre-1.2.0 state.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -169,9 +169,15 @@ module.exports = class Parser {
         }
       }
 
-      // if ((!this.current.nodes.length || (this.current.last && this.current.last.type === 'operator')) && this.nextToken[0] === 'word') {
-      if (this.nextToken[0] === 'word') {
-        return this.word();
+      if (!this.options.loose) {
+        if (this.nextToken[0] === 'word') {
+          return this.word();
+        }
+      }
+      else {
+        if ((!this.current.nodes.length || (this.current.last && this.current.last.type === 'operator')) && this.nextToken[0] === 'word') {
+          return this.word();
+        }
       }
     }
 

--- a/test/number.js
+++ b/test/number.js
@@ -153,7 +153,7 @@ describe('Parser → Number : Loose', () => {
     },
     {
       test: '5+5',
-      expected: { value: '+5', unit: '', length: 2 }
+      expected: { value: '5', unit: '', length: 3 }
     },
     {
       test: '5+-+-+-+5',
@@ -161,7 +161,7 @@ describe('Parser → Number : Loose', () => {
     },
     {
       test: '-16px -1px -1px -16px',
-      expected: { value: '-16', unit: 'px', length: 4 }
+      expected: { value: '-16', unit: 'px', length: 7 }
     }
   ];
 

--- a/test/number.js
+++ b/test/number.js
@@ -160,8 +160,8 @@ describe('Parser → Number : Loose', () => {
       expected: { value: '+5', unit: '', length: 8 }
     },
     {
-      test: '-16px -1px -1px -16px',
-      expected: { value: '-16', unit: 'px', length: 7 }
+      test: '-16px -1px -1px 16px',
+      expected: { value: '16', unit: 'px', length: 6 }
     }
   ];
 


### PR DESCRIPTION
When the `loose` option is `true`, numbers with operators will now be parsed the same way as in `1.1.0`.

**Which issue #** if any, does this resolve?
No issue on this repo, but it closes https://github.com/lesshint/lesshint/issues/340.

<!-- PRs must be accompanied by related tests -->

Please check one:
- [ ] New tests created for this change
- [x] Tests updated for this change

---

<!-- add additional comments here -->
The tests updates was made to reflect the correct number of nodes when `loose` is `true`. Unsure if any additional tests are needed, let me know if that's the case!