### PR TITLE
Fix function nesting

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -41,6 +41,7 @@ module.exports = class Parser {
     this.root.append(value);
 
     this.current = value;
+    this.stack = [this.current];
     this.tokens = tokenize(input, this.options);
   }
 
@@ -266,7 +267,7 @@ module.exports = class Parser {
 
     if (last && last.type === 'func' && last.unbalanced < 0) {
       last.unbalanced = 0; // ok we're ready to add parens now
-      this.cache = this.current;
+      this.stack.push(this.current);
       this.current = last;
     }
 
@@ -345,19 +346,14 @@ module.exports = class Parser {
 
     this.position ++;
 
-    if (this.position >= this.tokens.length - 1) {
-      return;
-    }
-
     this.current.unbalanced --;
 
     if (this.current.unbalanced < 0) {
       this.error('Expected opening parenthesis', token);
     }
 
-    if (!this.current.unbalanced && this.cache) {
-      this.current = this.cache;
-      this.cache = null;
+    if (!this.current.unbalanced && this.stack.length) {
+      this.current = this.stack.pop();
     }
   }
 

--- a/test/function.js
+++ b/test/function.js
@@ -118,6 +118,19 @@ describe('Parser → Function', () => {
         { type: 'number', value: '0' },
         { type: 'paren', value: ')' }
       ]
+    },
+    {
+      it: 'should parse nested function',
+      test: 'a(b())',
+      level: true,
+      expected: [
+        { type: 'func', value: 'a', level: 1 },
+          { type: 'paren', value: '(', level: 2 },
+          { type: 'func', value: 'b', level: 2 },
+            { type: 'paren', value: '(', level: 3 },
+            { type: 'paren', value: ')', level: 3 },
+          { type: 'paren', value: ')', level: 2 }
+      ]
     }
   ];
 
@@ -131,11 +144,24 @@ describe('Parser → Function', () => {
       let ast = new Parser(fixture.test).parse(),
         index = 0;
 
+      function getLevel (node) {
+        let level = -1;
+        while (node.parent) {
+          node = node.parent;
+          level++;
+        }
+        return level;
+      }
+
       // console.log(ast.first.first.nodes);
 
       ast.first.walk((node) => {
         let expected = fixture.expected[index];
         index ++;
+
+        if (fixture.level) {
+          node.level = getLevel(node);
+        }
 
         if (expected) {
           expect(node).to.shallowDeepEqual(expected);


### PR DESCRIPTION
The parenthesis is not added at the right place because it's using a single value instead of a stack in order to backtrack.

Fixes #26
