### PR TITLE
Remove senseless points

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ postcss-selector-parser.
 So we needed an alternative, and drew upon all three projects to put together a
 value parser that met and exceeded our needs. The improvements include:
 
-- Written using ES6
-- Uses the same Gulp toolchain as PostCSS
-- Doesn't strip characters; eg. parenthesis
-- Full AST traversal
 - AST traversal based on node type
 - Simple methods to derive strings from the parsed result
 - Follows PostCSS patterns for whitespace between Nodes


### PR DESCRIPTION
- es6 doesn't care end user
- gulp is overhead in this case, postcss has much more tasks. Also doesn't care end user.
- value-parser doesn't strip parentheses from your css, just treats them as node type instead of value/token or something. If you meant something different, the message is confusing
- There's walk helpers which may traverse full ast