### PR TITLE
fix: hexadecimal notation with 4 characters

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -463,7 +463,7 @@ module.exports = class Parser {
 
         if (node.constructor.name === 'Word') {
           node.isHex = /^#(.+)/.test(value);
-          node.isColor = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(value);
+          node.isColor = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(value);
         }
         else {
           this.cache.push(this.current);

--- a/test/word.js
+++ b/test/word.js
@@ -70,9 +70,10 @@ describe('Parser → Word', () => {
     },
     {
       it: 'should parse hex colors',
-      test: '#123 #abcdef #a2b3c4d5',
+      test: '#123 #f09f #abcdef #a2b3c4d5',
       expected: [
         { type: 'word', value: '#123', isHex: true, isColor: true },
+        { type: 'word', value: '#f09f', isHex: true, isColor: true },
         { type: 'word', value: '#abcdef', isHex: true, isColor: true },
         { type: 'word', value: '#a2b3c4d5', isHex: true, isColor: true  }
       ]


### PR DESCRIPTION
<!-- This template is *not* optional. If you remove this template or choose
not to complete it, your PR may be closed without review -->

**Which issue #** if any, does this resolve?

Support `#RGB[A]` notation as color notation

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

---

Ref: https://developer.mozilla.org/ru/docs/Web/CSS/color_value
