### PR TITLE
Protect constructors from empty opts

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -7,7 +7,7 @@ class Comment extends Node {
   constructor (opts) {
     super(opts);
     this.type = 'comment';
-    this.inline = opts.inline || false;
+    this.inline = Object(opts).inline || false;
   }
 
   toString () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,13 +23,11 @@ parser.atword = function (opts) {
 };
 
 parser.colon = function (opts) {
-  opts.value = opts.value || ':';
-  return new Colon(opts);
+  return new Colon(Object.assign({ value: ':' }, opts));
 };
 
 parser.comma = function (opts) {
-  opts.value = opts.value || ',';
-  return new Comma(opts);
+  return new Comma(Object.assign({ value: ',' }, opts));
 };
 
 parser.comment = function (opts) {
@@ -49,13 +47,11 @@ parser.operator = function (opts) {
 };
 
 parser.paren = function (opts) {
-  opts.value = opts.value || '(';
-  return new Paren(opts);
+  return new Paren(Object.assign({ value: '(' }, opts));
 };
 
 parser.string = function (opts) {
-  opts.quote = opts.quote || '\'';
-  return new Str(opts);
+  return new Str(Object.assign({ quote: '\'' }, opts));
 };
 
 parser.value = function (opts) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -201,10 +201,10 @@ module.exports = class Node {
   positionBy (opts) {
     let pos = this.source.start;
 
-    if (opts.index) {
+    if (Object(opts).index) {
       pos = this.positionInside(opts.index);
     }
-    else if (opts.word) {
+    else if (Object(opts).word) {
       let index = this.toString().indexOf(opts.word);
       if (index !== -1) pos = this.positionInside(index);
     }

--- a/lib/number.js
+++ b/lib/number.js
@@ -7,7 +7,7 @@ class NumberNode extends Node {
   constructor (opts) {
     super(opts);
     this.type = 'number';
-    this.unit = opts.unit || '';
+    this.unit = Object(opts).unit || '';
   }
 
   toString () {

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const expect = require('chai').expect;
+const Parser = require('../lib/parser');
+const ParserError = require('../lib/errors/ParserError');
+
+describe('Parser → Number', () => {
+  let fixtures = [
+    {
+      it: 'should clone an rgb function',
+      test: 'rgb(255, 0, 0)',
+      expected: [
+        { type: 'func', value: 'rgb' },
+        { type: 'paren', value: '(' },
+        { type: 'number', value: '255' },
+        { type: 'comma', value: ',' },
+        { type: 'number', value: '0' },
+        { type: 'comma', value: ',' },
+        { type: 'number', value: '0' },
+        { type: 'paren', value: ')' }
+      ]
+    }
+  ];
+
+  fixtures.forEach((fixture) => {
+    it(fixture.it, () => {
+      let ast = new Parser(fixture.test, { loose: fixture.loose }).parse().clone(),
+        index = 0;
+
+      ast.first.walk((node) => {
+        let expected = fixture.expected[index];
+        index ++;
+
+        if (expected) {
+          expect(node).to.shallowDeepEqual(expected);
+        }
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
**Which issue #** if any, does this resolve?

There is a critical issue cloning nodes with children. The internal cloning function calls Node constructors without arguments, but those constructors require them. There were no tests for this. This PR:

1. Adds a test that triggers the existing error.
2. Fixes all affected constructors, causing the test to pass.

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

---

Some Node constructors require an options argument that is an object (See https://github.com/shellscape/postcss-values-parser/blob/v1.5.0/lib/number.js#L7-L11)

```js
class NumberNode extends Node {
  constructor (opts) {
    super(opts);
    this.type = 'number';
    this.unit = opts.unit || ''; // <- See that opts must present and an object
  }
```

However, the internal `cloneNode` function does pass any parameters to constructors (See https://github.com/shellscape/postcss-values-parser/blob/v1.5.0/lib/node.js#L4).

```js
let cloned = new obj.constructor(); // <- See that nothing will be passed
```

Therefore, when cloning a parent node like `rgb(255, 0, 0)`, this tool throws an error: `Cannot read property 'unit' of undefined`.

This error has been reported in one of my projects using postcss-values-parser: https://github.com/postcss/postcss-custom-properties/issues/134

---

This PR allows Node constructors to work without an object.

Could this be slipped into a PATCH release?