### PR TITLE
Fix parsing double slash comments inside Sass maps

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -152,7 +152,7 @@ module.exports = function tokenize (input, options) {
 
       case closeParen:
         parentCount--;
-        isURLArg = !isURLArg && parentCount === 1;
+        isURLArg = isURLArg && parentCount > 0;
         tokens.push([')', ')',
           line, pos  - offset,
           line, next - offset,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-values-parser",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2700,9 +2700,9 @@
       }
     },
     "natives": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.5.tgz",
-      "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "natural-compare": {

--- a/test/comment.js
+++ b/test/comment.js
@@ -108,6 +108,37 @@ describe('Parser → Comment', () => {
       ]
     },
     {
+      it: 'should parse double slash comments after nested function inside url function',
+      test: 'url(var()//comment\n)',
+      loose: true,
+      expected: [
+        { type: 'func', value: 'url' },
+        { type: 'paren', value: '(' },
+        { type: 'func', value: 'var' },
+        { type: 'paren', value: '(' },
+        { type: 'paren', value: ')' },
+        { type: 'comment', value: 'comment' },
+        { type: 'paren', value: ')' }
+      ]
+    },
+    {
+      it: 'should parse double slash comments inside Sass maps',
+      test: '(a:(b:c)//comment\n)',
+      loose: true,
+      expected: [
+        { type: 'paren', value: '(' },
+        { type: 'word', value: 'a' },
+        { type: 'colon', value: ':' },
+        { type: 'paren', value: '(' },
+        { type: 'word', value: 'b' },
+        { type: 'colon', value: ':' },
+        { type: 'word', value: 'c' },
+        { type: 'paren', value: ')' },
+        { type: 'comment', value: 'comment' },
+        { type: 'paren', value: ')' }
+      ]
+    },
+    {
       it: 'should parse only one double slash empty comment',
       test: '//\n',
       loose: true,


### PR DESCRIPTION
<!-- This template is *not* optional. If you remove this template or choose
not to complete it, your PR may be closed without review -->

**Which issue #** if any, does this resolve? prettier/prettier#4659

When parsing a value that is a Sass map, and when the map contains some nested parens (nested map or function call, the tokenizer fails to recognize double slash comments:
```
(
  a: ( b: c )
  // comment
)
```
or
```
(
  a: calc( 1 + 2 )
  // comment
)
```
These comments are parsed as operator(/)+operator(/)+word instead.

Caused by the `closeParen` handler in tokenizer incorrectly setting `isURLArg` to `true` after a closing nested paren, even when there's no `url()` involved at all.

Introduced in #51 (@evilebottnawi), the PR that added support for Sass-like double-slash comments.

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

---

<!-- add additional comments here -->
