### PR TITLE
fix: TypeScript file extension should be .ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/shellscape/postcss-values-parser",
   "bugs": "https://github.com/shellscape/postcss-values-parser/issues",
   "main": "lib/index.js",
-  "types": "lib/index.d.js",
+  "types": "lib/index.d.ts",
   "engines": {
     "node": ">=6.14.4"
   },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The TypeScript typings file is at `lib/index.d.ts`, whilst package.json refers to `lib/index.d.js`.