### PR TITLE
Upgrade is-url-superb from ^3.0.0 to ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,11 +2844,6 @@
         }
       }
     },
-    "ip-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
-    },
     "irregular-plurals": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
@@ -3045,12 +3040,9 @@
       "dev": true
     },
     "is-url-superb": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
-      "integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
-      "requires": {
-        "url-regex": "^5.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -5350,7 +5342,8 @@
     "tlds": {
       "version": "1.203.1",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
-      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
+      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -5516,15 +5509,6 @@
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
-      }
-    },
-    "url-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-      "requires": {
-        "ip-regex": "^4.1.0",
-        "tlds": "^1.203.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,8 @@
   ],
   "dependencies": {
     "color-name": "^1.1.4",
-    "is-url-superb": "^3.0.0",
-    "postcss": "^7.0.5",
-    "url-regex": "^5.0.0"
+    "is-url-superb": "^4.0.0",
+    "postcss": "^7.0.5"
   },
   "devDependencies": {
     "ava": "^3.5.1",


### PR DESCRIPTION
WIP: tests do not pass. Is there anyone more familiar around? :)

```
  -         isUrl: false,
  +         isUrl: true,
            isVariable: false,
  -         parent: [Circular],
  +         parent: [Circular],
```

The major 4.0.0 drop dependency on `url-regex`, which has a up until now unpatched high vulnerability https://www.npmjs.com/advisories/1550

Next I remove the non-direct dependency of `postcss-values-parser` on `url-regex`, which I suppose was there to keep the version stable in case is-url-superb@^3.0.0 updated it, since it not imported anywhere in this `postcss-values-parser`.

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [x] yes
- [ ] no

New major of `is-url-superb`:
- requires Node.js 10
- no longer accepts protocol-relative URLs.

See https://github.com/sindresorhus/is-url-superb/releases/tag/v4.0.0

### Please Describe Your Changes

This relates to #120