### PR TITLE
chore!: upgrade is-url-superb to ^4.0.0

### DIFF
--- a/lib/nodes/Word.js
+++ b/lib/nodes/Word.js
@@ -37,7 +37,7 @@ class Word extends Node {
     const { value } = lastNode;
     lastNode.isColor = colorRegex.test(value) || colorNames.includes(value.toLowerCase());
     lastNode.isHex = hexRegex.test(value);
-    lastNode.isUrl = isUrl(value);
+    lastNode.isUrl = value.startsWith('//') ? isUrl(`http:${value}`) : isUrl(value);
     lastNode.isVariable = Word.testVariable(tokens[0], parser);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,9 +2794,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.17",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
-          "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==",
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
           "dev": true
         },
         "mimic-fn": {
@@ -3673,9 +3673,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
-      "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -4588,57 +4588,6 @@
       "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
       "dev": true
     },
-    "postcss-values-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.0.3.tgz",
-      "integrity": "sha512-3CeKsaGw5TOqJt79VVfu3EdbuShxq60jX45dVZ2Fd9z4b8acVfUwAtA2Nr1HkxZh3ypUV/tVkCKfuwY0abvsiw==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.1.4",
-        "is-number": "^7.0.0",
-        "is-url-superb": "^2.0.0",
-        "postcss": "^7.0.5",
-        "url-regex": "^4.1.1"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-          "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
-          "dev": true
-        },
-        "is-url-superb": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-2.0.0.tgz",
-          "integrity": "sha1-tyihjPaS5NFtprlMdAioEdsNBJI=",
-          "dev": true,
-          "requires": {
-            "url-regex": "^3.0.0"
-          },
-          "dependencies": {
-            "url-regex": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-              "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-              "dev": true,
-              "requires": {
-                "ip-regex": "^1.0.1"
-              }
-            }
-          }
-        },
-        "url-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-4.1.1.tgz",
-          "integrity": "sha512-ViSDgDPNKkrQHI81GLCjdDN+Rsk3tAW/uLXlBOJxtcHzWZjta58Z0APXhfXzS89YszsheMnEvXeDXsWUB53wwA==",
-          "dev": true,
-          "requires": {
-            "ip-regex": "^1.0.1",
-            "tlds": "^1.187.0"
-          }
-        }
-      }
-    },
     "pre-commit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
@@ -5255,9 +5204,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.17",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
-          "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==",
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
           "dev": true
         },
         "string-width": {
@@ -5337,12 +5286,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-      "dev": true
-    },
-    "tlds": {
-      "version": "1.203.1",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
-      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==",
       "dev": true
     },
     "tmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,11 +2844,6 @@
         }
       }
     },
-    "ip-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
-    },
     "irregular-plurals": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
@@ -3045,12 +3040,9 @@
       "dev": true
     },
     "is-url-superb": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
-      "integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
-      "requires": {
-        "url-regex": "^5.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -5350,7 +5342,8 @@
     "tlds": {
       "version": "1.203.1",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
-      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
+      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -5516,15 +5509,6 @@
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
-      }
-    },
-    "url-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-      "requires": {
-        "ip-regex": "^4.1.0",
-        "tlds": "^1.203.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">=6.14.4"
+    "node": ">=10"
   },
   "scripts": {
     "ci:coverage": "nyc npm run test && nyc report --reporter=text-lcov > coverage.lcov",
@@ -31,9 +31,8 @@
   ],
   "dependencies": {
     "color-name": "^1.1.4",
-    "is-url-superb": "^3.0.0",
-    "postcss": "^7.0.5",
-    "url-regex": "^5.0.0"
+    "is-url-superb": "^4.0.0",
+    "postcss": "^7.0.5"
   },
   "devDependencies": {
     "ava": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "nyc": "^15.0.0",
     "perfy": "^1.1.5",
     "postcss-value-parser": "^4.0.0",
-    "postcss-values-parser": "^3.0.3",
     "pre-commit": "^1.2.2",
     "prettier": "^2.0.1",
     "strip-ansi": "^6.0.0",

--- a/perf/perf.js
+++ b/perf/perf.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 const globby = require('globby');
 const perfy = require('perfy');
 const valueParser = require('postcss-value-parser');
-const v2Parser = require('postcss-values-parser');
+
 const strip = require('strip-ansi');
 const table = require('text-table');
 
@@ -37,14 +37,6 @@ const { parse } = require('../');
         theirs = perfy.end('value-parser');
       } catch (e) {
         theirs = { milliseconds: NaN };
-      }
-
-      perfy.start('v2');
-      try {
-        v2Parser(test).parse();
-        v2 = perfy.end('v2');
-      } catch (e) {
-        v2 = { milliseconds: NaN };
       }
 
       results.push({


### PR DESCRIPTION
- remove url-regex dependency

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [x] yes
- [ ] no

If yes, please describe the breakage.
Requires node V10
### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
upgrade is-url-superb to ^4.0.0 to fix audit. Also removes url-regex as a dep.
Related: https://github.com/shellscape/postcss-values-parser/issues/120

In the other PR, you mentioned not wanting to add any new code (https://github.com/shellscape/postcss-values-parser/pull/124#issuecomment-675115889), would this small change be fine?