### PR TITLE
Fix docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ root.walkNumerics((node) => nodes.push(node));
 //   ...
 // },
 // Numeric {
-//   value: '3s',
+//   value: '3',
 //   type: 'numeric',
 //   unit: 'pt',
 //   ...


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

This PR fixes a typo in the `docs/README.md` file in regards to parsing of numerics. The docs erroneously says the `3pt` value is parsed into a Numeric of value `3s` instead of `3`.