### PR TITLE
fix: move devDependencies where they belong to

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,15 +55,14 @@
     "postcss": "^8.4.14"
   },
   "dependencies": {
-    "@dot/versioner": "^0.4.2",
     "color-name": "^1.1.4",
     "css-tree": "^3.1.0",
-    "husky": "^9.1.7",
     "is-url-superb": "^4.0.0",
     "quote-unquote": "^1.0.0"
   },
   "devDependencies": {
     "@ava/typescript": "^6.0.0",
+    "@dot/versioner": "^0.4.2",
     "@ianvs/prettier-plugin-sort-imports": "^4.4.2",
     "@types/color-name": "^2.0.0",
     "@types/css-tree": "^2.3.10",
@@ -74,6 +73,7 @@
     "ava": "^6.4.0",
     "chalk": "^5.4.1",
     "globby": "^14.1.0",
+    "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "oxlint": "^1.3.0",
     "perfy": "^1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,12 @@ importers:
 
   .:
     dependencies:
-      '@dot/versioner':
-        specifier: ^0.4.2
-        version: 0.4.2
       color-name:
         specifier: ^1.1.4
         version: 1.1.4
       css-tree:
         specifier: ^3.1.0
         version: 3.1.0
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       is-url-superb:
         specifier: ^4.0.0
         version: 4.0.0
@@ -30,6 +24,9 @@ importers:
       '@ava/typescript':
         specifier: ^6.0.0
         version: 6.0.0
+      '@dot/versioner':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.4.2
         version: 4.4.2(prettier@3.6.2)
@@ -60,6 +57,9 @@ importers:
       globby:
         specifier: ^14.1.0
         version: 14.1.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       lint-staged:
         specifier: ^16.1.2
         version: 16.1.2


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

After #149, `husky` and `@dot/versioner` were wrongfully included in dependencies.

/CC @shellscape 