### PR TITLE
chore: replace `strip-ansi` with node native `stripVTControlCharacters`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "prettier": "^3.6.2",
     "prettier-plugin-package": "^1.4.0",
     "rewiremock": "^3.14.6",
-    "strip-ansi": "^7.1.0",
     "text-table": "^0.2.0",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",

--- a/perf/perf.ts
+++ b/perf/perf.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 
 import chalk from 'chalk';
 import { globby } from 'globby';
 import perfy from 'perfy';
 import valueParser from 'postcss-value-parser';
-import stripAnsi from 'strip-ansi';
 import table from 'text-table';
 
 import { parse } from '../dist/index.js';
@@ -73,8 +73,8 @@ interface TestResult {
       ours > theirs
         ? chalk.red(ours.toString())
         : theirs > ours
-        ? chalk.green(ours.toString())
-        : ours.toString(),
+          ? chalk.green(ours.toString())
+          : ours.toString(),
       theirs.toString()
     ]);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       rewiremock:
         specifier: ^3.14.6
         version: 3.14.6
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       text-table:
         specifier: ^0.2.0
         version: 0.2.0


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes
Hi! This PR replaces `strip-ansi` dependency with nodejs native `stripVTControlCharacters` from `node:util` available since node 16.11.0

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
